### PR TITLE
schema response fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Follow these steps to set up and run the Django project:
    ```bash
    docker run -p 8000:8000 bitespeed-identity-reconciliation
 
+
 - Now the application will be live on http://localhost:8000/
 - Please visit the Documentation for schema and api contracts
 - [Task Endpoint](http://localhost:8000/api/identity/)

--- a/api/views.py
+++ b/api/views.py
@@ -30,7 +30,8 @@ class IdentityView(APIView):
                 "contact": serializers.DictField(default={
                     "primaryContatctId": 7,
 			        "emails": [],
-			        "phoneNumbers": []
+			        "phoneNumbers": [],
+                    "secondaryContactIds": []
                 })
             }
         )


### PR DESCRIPTION
schema for response to POST "/api/identity/" was wrong in swagger and redoc, this update is to fix that.